### PR TITLE
performance workaround

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,13 @@ const defaults = {
   fontSize: 16
 };
 
-module.exports = postcss.plugin('postcss-pr', (opts = defaults) => {
+module.exports = postcss.plugin('postcss-pr', (opts) => {
+  opts = opts || {};
+  const userFontSize = opts.fontSize;
+  opts = Object.assign(opts, defaults);
+
   return (css) => {
-    const rootFontSize = getRootSize(css, opts) || opts.fontSize;
+    const rootFontSize = userFontSize || getRootSize(css, opts) || opts.fontSize;
     const prReg = new RegExp('\\(?\\d*\\.?\\d+(px)?\\)?' + opts.unit, 'gi');
 
     css.replaceValues(prReg, {fast: opts.unit}, (val) => {


### PR DESCRIPTION
Dear @jameskolce if you don't mind I'd like to add a little workaround for performance like in postcss-pe.
So if user explicitly sets fontSize option thereby we omit getRootSize(), if not - run getRootSize(), if root isn't found - 16px by default.
`const rootFontSize = userFontSize || getRootSize(css, opts) || opts.fontSize;`